### PR TITLE
Adds CP API Inteface to SDK

### DIFF
--- a/controlplanes_api.go
+++ b/controlplanes_api.go
@@ -1,0 +1,20 @@
+package sdkkonnectgo
+
+import (
+	"context"
+	"github.com/Kong/sdk-konnect-go/models/components"
+	"github.com/Kong/sdk-konnect-go/models/operations"
+)
+
+type ControlPlaneAPI interface {
+	ListControlPlanes(ctx context.Context, request operations.ListControlPlanesRequest,
+		opts ...operations.Option) (*operations.ListControlPlanesResponse, error)
+	CreateControlPlane(ctx context.Context, request components.CreateControlPlaneRequest,
+		opts ...operations.Option) (*operations.CreateControlPlaneResponse, error)
+	GetControlPlane(ctx context.Context, id string,
+		opts ...operations.Option) (*operations.GetControlPlaneResponse, error)
+	UpdateControlPlane(ctx context.Context, id string, updateControlPlaneRequest components.UpdateControlPlaneRequest,
+		opts ...operations.Option) (*operations.UpdateControlPlaneResponse, error)
+	DeleteControlPlane(ctx context.Context, id string,
+		opts ...operations.Option) (*operations.DeleteControlPlaneResponse, error)
+}


### PR DESCRIPTION
This is helpful for clients of the SDK who wish test their usage of the ControlPlanes struct found in controlplanes.go. Eventually these could be generated from the spec, but for now we can hand code them here so they can be shared by clients